### PR TITLE
return the HashMap from createGroupPad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 org/**/*.class
+*.ipr
+*.iws
+*.iml

--- a/org/etherpad_lite_client/EPLiteClient.java
+++ b/org/etherpad_lite_client/EPLiteClient.java
@@ -122,11 +122,11 @@ public class EPLiteClient {
      * @param groupID string
      * @param padName string
      */
-    public void createGroupPad(String groupID, String padName) {
+    public HashMap createGroupPad(String groupID, String padName) {
         HashMap args = new HashMap();
         args.put("groupID", groupID);
         args.put("padName", padName);
-        this.post("createGroupPad", args);
+        return this.post("createGroupPad", args);
     }
 
     /**


### PR DESCRIPTION
I added a HashMap return from createGroupPad so that it is possible to get groupID from the call return.
